### PR TITLE
Update ingress.yaml

### DIFF
--- a/lab1_kubectl_version1/yaml/ingress.yaml
+++ b/lab1_kubectl_version1/yaml/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: guestbook-ingress
@@ -8,13 +8,19 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: frontend
-          servicePort: 80
+          service:
+            name: frontend
+            port:
+              number: 80
   - host: backend.minikube.local
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: backend
-          servicePort: 80
+          service:
+            name: backend
+            port:
+              number: 80


### PR DESCRIPTION
v1beta1 was deprecated in v1.14 and became unavailable in 1.22, was instructed to update to "networking.k8s.io/v1" which included a few more schema changes